### PR TITLE
Listen to all IP-adresses

### DIFF
--- a/src/background.js
+++ b/src/background.js
@@ -27,7 +27,7 @@ function startServer() {
 
   debugBarServer = net.createServer();
 
-  debugBarServer.listen(mainStorage.get('port'), '127.0.0.1', () => {
+  debugBarServer.listen(mainStorage.get('port'), '0.0.0.0', () => {
     console.log('TCP Server is running on port ' + mainStorage.get('port'));
   });
 


### PR DESCRIPTION
I was having a problem when getting the app working with Laravel running in Windows WSL2. Due to only listening to the local IP-address, Laravel wasn't able to connect to the server.

Changing the host to 0.0.0.0 means it will listen on every IP-address given.